### PR TITLE
Update windows path to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Turku Hacklab 3d printer Slic3r settings
 Pull the contents of this repository to:
 * Linux: ~/.Slic3r/ 
 * OSX: /Library/Application Support/Slic3r/
-* Windows: (insert knowledge here, plz)
+* Windows: (Install dir)/settings/


### PR DESCRIPTION
Slic3r works as portable so there's not a single directory for settings. This works fine.